### PR TITLE
SMA-75: add user info endpoint

### DIFF
--- a/backend/sportsmatch/src/main/java/com/sportsmatch/controllers/AuthController.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/controllers/AuthController.java
@@ -55,7 +55,11 @@ public class AuthController {
 
   @GetMapping("/me")
   @Tag(name = "ex.secured endpoint")
-  public UserDTO getUserMainPage() {
-    return userService.getUserDTOFromContext();
+  public ResponseEntity<?> getUserMainPage() {
+    try {
+      return ResponseEntity.ok().body(userService.getMyRank());
+    } catch (ResponseStatusException e) {
+      return ResponseEntity.badRequest().body(e.getStatusCode());
+    }
   }
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/controllers/AuthController.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/controllers/AuthController.java
@@ -2,7 +2,6 @@ package com.sportsmatch.controllers;
 
 import com.sportsmatch.auth.AuthService;
 import com.sportsmatch.dtos.AuthRequestDTO;
-import com.sportsmatch.dtos.UserDTO;
 import com.sportsmatch.services.UserService;
 import com.sportsmatch.services.ValidationService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/controllers/UserController.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/controllers/UserController.java
@@ -18,6 +18,15 @@ public class UserController {
   private final ValidationService validationService;
   private final UserService userService;
 
+  @GetMapping("/get/{username}")
+  public ResponseEntity<?> getUser(@PathVariable String username) {
+    try {
+      return ResponseEntity.ok().body(userService.getUserByName(username));
+    } catch (ResponseStatusException e) {
+      return ResponseEntity.status(e.getStatusCode()).build();
+    }
+  }
+
   @PostMapping("/update")
   public ResponseEntity<?> updateInfo(
       @RequestBody @Valid UserInfoDTO userInfoDTO, BindingResult bindingResult) {

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/dtos/UserDTO.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/dtos/UserDTO.java
@@ -1,8 +1,7 @@
 package com.sportsmatch.dtos;
 
-import lombok.*;
-
 import java.util.List;
+import lombok.*;
 
 @Getter
 @Setter
@@ -12,6 +11,6 @@ import java.util.List;
 public class UserDTO {
 
   private String name;
-  private List<SportDTO> sports;
   private Integer elo;
+  private List<SportDTO> sports;
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/dtos/UserDTO.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/dtos/UserDTO.java
@@ -2,6 +2,8 @@ package com.sportsmatch.dtos;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -10,4 +12,6 @@ import lombok.*;
 public class UserDTO {
 
   private String name;
+  private List<SportDTO> sports;
+  private Integer elo;
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/mappers/SportMapper.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/mappers/SportMapper.java
@@ -13,7 +13,7 @@ public class SportMapper {
    * @param entity The Sport entity to be converted.
    * @return SportDTO containing information from the Sport entity.
    */
-  public static SportDTO toDTO(Sport entity) {
+  public SportDTO toDTO(Sport entity) {
     return SportDTO.builder()
         .name(entity.getName())
         .emoji(entity.getEmoji())

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/models/Event.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/models/Event.java
@@ -38,6 +38,8 @@ public class Event {
 
   private String title;
 
+  private Boolean isRanksUpdated = false;
+
   @OneToMany(cascade = CascadeType.ALL, mappedBy = "event")
   private Set<EventPlayer> players = new HashSet<>();
 

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/models/User.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/models/User.java
@@ -35,6 +35,14 @@ public class User implements UserDetails {
 
   private Gender gender;
 
+  private Integer rank = 1000;
+
+  private Integer win;
+
+  private Integer loss;
+
+  private Integer totalPlayed;
+
   @Enumerated(EnumType.STRING)
   private Role role;
 

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/models/User.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/models/User.java
@@ -37,11 +37,11 @@ public class User implements UserDetails {
 
   private Integer rank = 1000;
 
-  private Integer win;
+  private Integer win = 0;
 
-  private Integer loss;
+  private Integer loss = 0;
 
-  private Integer totalPlayed;
+  private Integer totalPlayed = 0;
 
   @Enumerated(EnumType.STRING)
   private Role role;

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/repositories/UserRepository.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/repositories/UserRepository.java
@@ -15,5 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
 
+  Optional<User> findUserByName(String name);
+
   boolean existsByEmail(String email);
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/EventService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/EventService.java
@@ -192,4 +192,23 @@ public class EventService {
       throw new Exception("Event has already two players.");
     }
   }
+
+  public boolean isValidEvent(Event event) {
+    EventPlayer firstPlayer = null;
+
+    for (EventPlayer e : event.getPlayers()) {
+      int myScore = e.getMyScore();
+      int opponentScore = e.getOpponentScore();
+
+      if (firstPlayer == null) {
+        firstPlayer = e;
+      } else {
+        if (myScore != firstPlayer.getOpponentScore()
+            || opponentScore != firstPlayer.getMyScore()) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/EventService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/EventService.java
@@ -192,23 +192,4 @@ public class EventService {
       throw new Exception("Event has already two players.");
     }
   }
-
-  public boolean isValidEvent(Event event) {
-    EventPlayer firstPlayer = null;
-
-    for (EventPlayer e : event.getPlayers()) {
-      int myScore = e.getMyScore();
-      int opponentScore = e.getOpponentScore();
-
-      if (firstPlayer == null) {
-        firstPlayer = e;
-      } else {
-        if (myScore != firstPlayer.getOpponentScore()
-            || opponentScore != firstPlayer.getMyScore()) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
@@ -1,0 +1,95 @@
+package com.sportsmatch.services;
+
+import com.sportsmatch.models.Event;
+import com.sportsmatch.models.EventPlayer;
+import com.sportsmatch.models.User;
+import com.sportsmatch.repositories.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RankService {
+
+  @Value("${app.sportsmingle.num-game-threshold}")
+  private int[] NUM_GAME_THRESHOLD;
+
+  @Value("${app.sportsmingle.k-factors}")
+  private double[] K_FACTORS;
+
+  @Value("${app.sportsmingle.k-factor-default}")
+  private double DEFAULT_K_FACTOR;
+
+  private final EventService eventService;
+  private final EventRepository eventRepository;
+
+  public void updatePlayersRanks(Event event) {
+    if (!eventService.isValidEvent(event) || event.getIsRanksUpdated()) {
+      return;
+    }
+
+    if (event.getPlayers().size() < 2) {
+      throw new IllegalArgumentException("An event must have at least two players.");
+    }
+
+    List<EventPlayer> players = new ArrayList<>(event.getPlayers());
+    EventPlayer firstPlayer = players.get(0);
+    EventPlayer secondPlayer = players.get(1);
+
+    firstPlayer.getPlayer().setRank(newRating(firstPlayer, secondPlayer));
+    secondPlayer.getPlayer().setRank(newRating(secondPlayer, firstPlayer));
+    event.setIsRanksUpdated(true);
+
+    eventRepository.save(event);
+  }
+
+  private double calculateTransformedRating(User user) {
+    return Math.pow(10, ((double) user.getRank() / 400));
+  }
+
+  private double expectedScore(User firstPlayer, User secondPlayer) {
+    double firstTransformedRating = calculateTransformedRating(firstPlayer);
+    double secondTransformedRating = calculateTransformedRating(secondPlayer);
+    return firstTransformedRating / (firstTransformedRating + secondTransformedRating);
+  }
+
+  private int newRating(EventPlayer firstPlayer, EventPlayer secondPlayer) {
+    double updatedRating =
+        firstPlayer.getPlayer().getRank()
+            + adjustKFactor(firstPlayer.getPlayer())
+                * ((getScore(firstPlayer))
+                    - expectedScore(firstPlayer.getPlayer(), secondPlayer.getPlayer()));
+    return (int) Math.round(updatedRating);
+  }
+
+  private double getScore(EventPlayer eventPlayer) {
+    double myScore = eventPlayer.getMyScore();
+    double opponentScore = eventPlayer.getOpponentScore();
+    User player = eventPlayer.getPlayer();
+
+    player.setTotalPlayed(player.getTotalPlayed() + 1);
+
+    if (myScore > opponentScore) {
+      player.setWin(player.getWin() + 1);
+      return 1;
+    } else if (myScore == opponentScore) {
+      return 0.5;
+    } else {
+      player.setLoss(player.getLoss() + 1);
+      return 0;
+    }
+  }
+
+  private double adjustKFactor(User user) {
+    for (int i = 0; i < NUM_GAME_THRESHOLD.length; i++) {
+      if (user.getTotalPlayed() <= NUM_GAME_THRESHOLD[i]) {
+        return K_FACTORS[i];
+      }
+    }
+    return DEFAULT_K_FACTOR;
+  }
+}

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
@@ -4,26 +4,24 @@ import com.sportsmatch.models.Event;
 import com.sportsmatch.models.EventPlayer;
 import com.sportsmatch.models.User;
 import com.sportsmatch.repositories.EventRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class RankService {
 
-//  @Value("${app.sportsmingle.num-game-threshold}")
-  private List<Integer> NUM_GAME_THRESHOLD = new ArrayList<>(Arrays.asList(5,15,25));
+  //  @Value("${app.sportsmingle.num-game-threshold}")
+  private final List<Integer> NUM_GAME_THRESHOLD = new ArrayList<>(Arrays.asList(5, 15, 25));
 
-//  @Value("${app.sportsmingle.k-factors}")
-  private List<Double> K_FACTORS = new ArrayList<>(Arrays.asList(25.0,15.0,10.0));
+  //  @Value("${app.sportsmingle.k-factors}")
+  private final List<Double> K_FACTORS = new ArrayList<>(Arrays.asList(25.0, 15.0, 10.0));
 
-//  @Value("${app.sportsmingle.k-factor-default}")
-  private double DEFAULT_K_FACTOR = 5.0;
+  //  @Value("${app.sportsmingle.k-factor-default}")
+  private final double DEFAULT_K_FACTOR = 5.0;
 
   private final EventRepository eventRepository;
 

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
@@ -57,7 +57,7 @@ public class RankService {
             + adjustKFactor(firstPlayer.getPlayer())
                 * ((getScore(firstPlayer))
                     - expectedScore(firstPlayer.getPlayer(), secondPlayer.getPlayer()));
-    return (int) Math.round(updatedRating);
+    return (int) updatedRating;
   }
 
   private double getScore(EventPlayer eventPlayer) {

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
@@ -28,12 +28,10 @@ public class RankService {
   private final EventRepository eventRepository;
 
   public void updatePlayersRanks(Event event) {
-    if (!eventService.isValidEvent(event) || event.getIsRanksUpdated()) {
+    if (!eventService.isValidEvent(event)
+        || event.getIsRanksUpdated()
+        || event.getPlayers().size() < 2) {
       return;
-    }
-
-    if (event.getPlayers().size() < 2) {
-      throw new IllegalArgumentException("An event must have at least two players.");
     }
 
     List<EventPlayer> players = new ArrayList<>(event.getPlayers());

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
@@ -9,20 +9,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RankService {
 
-  @Value("${app.sportsmingle.num-game-threshold}")
-  private int[] NUM_GAME_THRESHOLD;
+//  @Value("${app.sportsmingle.num-game-threshold}")
+  private List<Integer> NUM_GAME_THRESHOLD = new ArrayList<>(Arrays.asList(5,15,25));
 
-  @Value("${app.sportsmingle.k-factors}")
-  private double[] K_FACTORS;
+//  @Value("${app.sportsmingle.k-factors}")
+  private List<Double> K_FACTORS = new ArrayList<>(Arrays.asList(25.0,15.0,10.0));
 
-  @Value("${app.sportsmingle.k-factor-default}")
-  private double DEFAULT_K_FACTOR;
+//  @Value("${app.sportsmingle.k-factor-default}")
+  private double DEFAULT_K_FACTOR = 5.0;
 
   private final EventRepository eventRepository;
 
@@ -80,9 +81,9 @@ public class RankService {
   }
 
   private double adjustKFactor(User user) {
-    for (int i = 0; i < NUM_GAME_THRESHOLD.length; i++) {
-      if (user.getTotalPlayed() <= NUM_GAME_THRESHOLD[i]) {
-        return K_FACTORS[i];
+    for (int i = 0; i < NUM_GAME_THRESHOLD.size(); i++) {
+      if (user.getTotalPlayed() <= NUM_GAME_THRESHOLD.get(i)) {
+        return K_FACTORS.get(i);
       }
     }
     return DEFAULT_K_FACTOR;

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/RankService.java
@@ -24,13 +24,10 @@ public class RankService {
   @Value("${app.sportsmingle.k-factor-default}")
   private double DEFAULT_K_FACTOR;
 
-  private final EventService eventService;
   private final EventRepository eventRepository;
 
   public void updatePlayersRanks(Event event) {
-    if (!eventService.isValidEvent(event)
-        || event.getIsRanksUpdated()
-        || event.getPlayers().size() < 2) {
+    if (!isEventValid(event) || event.getIsRanksUpdated() || event.getPlayers().size() < 2) {
       return;
     }
 
@@ -89,5 +86,24 @@ public class RankService {
       }
     }
     return DEFAULT_K_FACTOR;
+  }
+
+  private boolean isEventValid(Event event) {
+    EventPlayer firstPlayer = null;
+
+    for (EventPlayer e : event.getPlayers()) {
+      int myScore = e.getMyScore();
+      int opponentScore = e.getOpponentScore();
+
+      if (firstPlayer == null) {
+        firstPlayer = e;
+      } else {
+        if (myScore != firstPlayer.getOpponentScore()
+            || opponentScore != firstPlayer.getMyScore()) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/SportServiceImp.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/SportServiceImp.java
@@ -17,7 +17,6 @@ public class SportServiceImp implements SportService {
   private final SportRepository sportRepository;
   private final SportMapper sportMapper;
 
-
   /**
    * {@summary <p>This method returns a paginated list of SportsDTO.</p>}
    *
@@ -25,8 +24,7 @@ public class SportServiceImp implements SportService {
    * @return paginated list of SportDTO.
    */
   public List<SportDTO> getAllSports(final Pageable pageable) {
-    return sportRepository.findAll(pageable)
-        .stream()
+    return sportRepository.findAll(pageable).stream()
         .map(sportMapper::toDTO)
         .collect(Collectors.toList());
   }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/SportServiceImp.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/SportServiceImp.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 public class SportServiceImp implements SportService {
 
   private final SportRepository sportRepository;
+  private final SportMapper sportMapper;
 
 
   /**
@@ -26,7 +27,7 @@ public class SportServiceImp implements SportService {
   public List<SportDTO> getAllSports(final Pageable pageable) {
     return sportRepository.findAll(pageable)
         .stream()
-        .map(SportMapper::toDTO)
+        .map(sportMapper::toDTO)
         .collect(Collectors.toList());
   }
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserService.java
@@ -12,4 +12,6 @@ public interface UserService {
   UserDTO getUserDTOFromContext();
 
   void updateUserInfo(UserInfoDTO userInfoDTO);
+
+  UserDTO getUserByName(String name);
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserService.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserService.java
@@ -1,6 +1,5 @@
 package com.sportsmatch.services;
 
-
 import com.sportsmatch.dtos.UserDTO;
 import com.sportsmatch.dtos.UserInfoDTO;
 import com.sportsmatch.models.User;
@@ -14,4 +13,6 @@ public interface UserService {
   void updateUserInfo(UserInfoDTO userInfoDTO);
 
   UserDTO getUserByName(String name);
+
+  UserDTO getMyRank();
 }

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserServiceImp.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserServiceImp.java
@@ -57,6 +57,11 @@ public class UserServiceImp implements UserService {
     return userMapper.toDTO(getUserFromContext());
   }
 
+  public UserDTO getMyRank() {
+    User user = getUserFromContext();
+    return getUserByName(user.getName());
+  }
+
   public UserDTO getUserByName(String username) {
     Optional<User> user = userRepository.findUserByName(username);
 

--- a/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserServiceImp.java
+++ b/backend/sportsmatch/src/main/java/com/sportsmatch/services/UserServiceImp.java
@@ -3,14 +3,11 @@ package com.sportsmatch.services;
 import com.sportsmatch.dtos.UserDTO;
 import com.sportsmatch.mappers.SportMapper;
 import com.sportsmatch.mappers.UserMapper;
-import com.sportsmatch.models.Sport;
-import com.sportsmatch.models.User;
+import com.sportsmatch.models.*;
 import com.sportsmatch.repositories.SportRepository;
 import com.sportsmatch.repositories.UserRepository;
 import com.sportsmatch.dtos.SportDTO;
 import com.sportsmatch.dtos.UserInfoDTO;
-import com.sportsmatch.models.Gender;
-import com.sportsmatch.models.SportUser;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +19,8 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -33,6 +32,7 @@ public class UserServiceImp implements UserService {
   private final SportMapper sportMapper;
   private final SportRepository sportRepository;
   private final UserMapper userMapper;
+  private final RankService rankService;
 
   /**
    * This method retrieves the authenticated user from the SecurityContextHolder. It checks if the
@@ -55,6 +55,27 @@ public class UserServiceImp implements UserService {
 
   public UserDTO getUserDTOFromContext() {
     return userMapper.toDTO(getUserFromContext());
+  }
+
+  public UserDTO getUserByName(String username) {
+    Optional<User> user = userRepository.findUserByName(username);
+
+    if (user.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    }
+
+    List<EventPlayer> events = new ArrayList<>(user.get().getEventsPlayed());
+    List<SportDTO> sports = new ArrayList<>();
+    for (EventPlayer e : events) {
+      rankService.updatePlayersRanks(e.getEvent());
+      sports.add(sportMapper.toDTO(e.getEvent().getSport()));
+    }
+
+    return UserDTO.builder()
+        .name(user.get().getName())
+        .sports(sports)
+        .elo(user.get().getRank())
+        .build();
   }
 
   @Transactional

--- a/backend/sportsmatch/src/main/resources/application.properties
+++ b/backend/sportsmatch/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.mvc.hiddenmethod.filter.enabled=true
 app.sportsmingle.initialization.database-init=true
 app.sportsmingle.jwt.secret=56e1a2c8b7a56f5c480cf0045186dbc514d9172e4fbbc81dd82f541384274c3c
 app.sportsmingle.frontend.url=http://localhost:5173
+
+app.sportsmingle.num-game-threshold=10,50,100
+app.sportsmingle.k-factors=25.0,15.0,10.0
+app.sportsmingle.k-factor-default=5.0

--- a/backend/sportsmatch/src/main/resources/application.properties
+++ b/backend/sportsmatch/src/main/resources/application.properties
@@ -11,6 +11,6 @@ app.sportsmingle.initialization.database-init=true
 app.sportsmingle.jwt.secret=56e1a2c8b7a56f5c480cf0045186dbc514d9172e4fbbc81dd82f541384274c3c
 app.sportsmingle.frontend.url=http://localhost:5173
 
-app.sportsmingle.num-game-threshold=10,50,100
+app.sportsmingle.num-game-threshold=5,15,25
 app.sportsmingle.k-factors=25.0,15.0,10.0
 app.sportsmingle.k-factor-default=5.0

--- a/backend/sportsmatch/src/test/java/com/sportsmatch/services/RankServiceTest.java
+++ b/backend/sportsmatch/src/test/java/com/sportsmatch/services/RankServiceTest.java
@@ -57,8 +57,8 @@ class RankServiceTest extends BaseTest {
 
     rankService.updatePlayersRanks(event);
 
-    assertEquals(1013, firstUser.getRank());
-    assertEquals(988, secondUser.getRank());
+    assertEquals(1012, firstUser.getRank());
+    assertEquals(987, secondUser.getRank());
     assertTrue(event.getIsRanksUpdated());
     verify(eventRepository, times(1)).save(event);
   }

--- a/backend/sportsmatch/src/test/java/com/sportsmatch/services/RankServiceTest.java
+++ b/backend/sportsmatch/src/test/java/com/sportsmatch/services/RankServiceTest.java
@@ -1,0 +1,65 @@
+package com.sportsmatch.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.sportsmatch.BaseTest;
+import com.sportsmatch.models.Event;
+import com.sportsmatch.models.EventPlayer;
+import com.sportsmatch.models.User;
+import com.sportsmatch.repositories.EventRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.TestPropertySource;
+
+@ExtendWith(MockitoExtension.class)
+@TestPropertySource(locations = "classpath:application-test.properties")
+class RankServiceTest extends BaseTest {
+
+  @Mock EventRepository eventRepository;
+  @InjectMocks RankService rankService;
+
+  @Test
+  void updatePlayersRanks() {
+
+    // User
+    User firstUser = new User();
+    firstUser.setRank(1000);
+    firstUser.setId(1L);
+
+    User secondUser = new User();
+    secondUser.setRank(1000);
+    secondUser.setId(2L);
+
+    // EventPlayer
+    EventPlayer firstPlayer = new EventPlayer();
+    firstPlayer.setId(1L);
+    firstPlayer.setMyScore(5);
+    firstPlayer.setOpponentScore(2);
+    firstPlayer.setPlayer(firstUser);
+
+    EventPlayer secondPlayer = new EventPlayer();
+    secondPlayer.setId(2L);
+    secondPlayer.setMyScore(2);
+    secondPlayer.setOpponentScore(5);
+    secondPlayer.setPlayer(secondUser);
+
+    // Event
+    Event event = new Event();
+    event.setId(1L);
+    event.getPlayers().add(firstPlayer);
+    event.getPlayers().add(secondPlayer);
+
+    rankService.updatePlayersRanks(event);
+
+    assertEquals(1012, firstUser.getRank());
+    assertEquals(988, secondUser.getRank());
+    assertTrue(event.getIsRanksUpdated());
+    verify(eventRepository, times(1)).save(event);
+  }
+}

--- a/backend/sportsmatch/src/test/java/com/sportsmatch/services/RankServiceTest.java
+++ b/backend/sportsmatch/src/test/java/com/sportsmatch/services/RankServiceTest.java
@@ -57,7 +57,7 @@ class RankServiceTest extends BaseTest {
 
     rankService.updatePlayersRanks(event);
 
-    assertEquals(1012, firstUser.getRank());
+    assertEquals(1013, firstUser.getRank());
     assertEquals(988, secondUser.getRank());
     assertTrue(event.getIsRanksUpdated());
     verify(eventRepository, times(1)).save(event);

--- a/backend/sportsmatch/src/test/java/com/sportsmatch/services/SportServiceImpTest.java
+++ b/backend/sportsmatch/src/test/java/com/sportsmatch/services/SportServiceImpTest.java
@@ -2,6 +2,7 @@ package com.sportsmatch.services;
 
 import com.sportsmatch.BaseTest;
 import com.sportsmatch.dtos.SportDTO;
+import com.sportsmatch.mappers.SportMapper;
 import com.sportsmatch.models.Sport;
 import com.sportsmatch.repositories.SportRepository;
 import com.sportsmatch.services.SportServiceImp;
@@ -25,20 +26,19 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class SportServiceImpTest extends BaseTest {
 
-  @Mock
-  private SportRepository sportRepository;
+  @Mock private SportRepository sportRepository;
 
+  @Mock private SportMapper sportMapper;
 
-  @InjectMocks
-  private SportServiceImp sportService;
+  @InjectMocks private SportServiceImp sportService;
 
   @Test
   void getAllSportsShouldReturnAllSportsWhenRequired() {
     // Arrange
     Pageable pageable = Mockito.mock(Pageable.class);
 
-    String footballEmoji = "\uD83E\uDD45"; //Goal net emoji
-    String basketballEmoji = "\uD83C\uDFC0"; //basketball emoji orange ball
+    String footballEmoji = "\uD83E\uDD45"; // Goal net emoji
+    String basketballEmoji = "\uD83C\uDFC0"; // basketball emoji orange ball
 
     Sport sport1 = new Sport("Football", footballEmoji, "urlFootball");
     Sport sport2 = new Sport("Basketball", basketballEmoji, "urlBasketball");
@@ -49,11 +49,13 @@ class SportServiceImpTest extends BaseTest {
     SportDTO sportDTO1 = new SportDTO("Football", footballEmoji, "urlFootball");
     SportDTO sportDTO2 = new SportDTO("Basketball", basketballEmoji, "urlBasketball");
 
+    when(sportMapper.toDTO(sport1)).thenReturn(sportDTO1);
+    when(sportMapper.toDTO(sport2)).thenReturn(sportDTO2);
+
     List<SportDTO> expectedSportDTOs = Arrays.asList(sportDTO1, sportDTO2);
 
     // Mocking repository
     when(sportRepository.findAll(any(Pageable.class))).thenReturn(sportsPage);
-
 
     // Act
     List<SportDTO> result = sportService.getAllSports(pageable);

--- a/backend/sportsmatch/src/test/java/com/sportsmatch/services/UserServiceImpTest.java
+++ b/backend/sportsmatch/src/test/java/com/sportsmatch/services/UserServiceImpTest.java
@@ -1,5 +1,9 @@
 package com.sportsmatch.services;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import com.sportsmatch.BaseTest;
 import com.sportsmatch.dtos.SportDTO;
 import com.sportsmatch.dtos.UserDTO;
@@ -7,6 +11,9 @@ import com.sportsmatch.dtos.UserInfoDTO;
 import com.sportsmatch.mappers.SportMapper;
 import com.sportsmatch.models.*;
 import com.sportsmatch.repositories.UserRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,14 +23,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImpTest extends BaseTest {
@@ -107,7 +106,7 @@ class UserServiceImpTest extends BaseTest {
     Sport sport = new Sport();
     sport.setId(1L);
     sport.setName("Tennis");
-    sport.setEmoji("\uD83C\uDFBE");
+    sport.setEmoji("🎾");
     sport.setBackgroundImageURL("./assets/sport-component-tennis.png");
 
     // SportUser

--- a/backend/sportsmatch/src/test/java/com/sportsmatch/services/UserServiceImpTest.java
+++ b/backend/sportsmatch/src/test/java/com/sportsmatch/services/UserServiceImpTest.java
@@ -2,12 +2,10 @@ package com.sportsmatch.services;
 
 import com.sportsmatch.BaseTest;
 import com.sportsmatch.dtos.SportDTO;
+import com.sportsmatch.dtos.UserDTO;
 import com.sportsmatch.dtos.UserInfoDTO;
 import com.sportsmatch.mappers.SportMapper;
-import com.sportsmatch.models.Gender;
-import com.sportsmatch.models.Sport;
-import com.sportsmatch.models.SportUser;
-import com.sportsmatch.models.User;
+import com.sportsmatch.models.*;
 import com.sportsmatch.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,14 +28,11 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class UserServiceImpTest extends BaseTest {
 
-  @Mock
-  private UserRepository userRepository;
-  @Mock
-  private SportMapper sportMapper;
-  @Mock
-  private SecurityContext securityContext;
-  @InjectMocks
-  private UserServiceImp userServiceImp;
+  @Mock private UserRepository userRepository;
+  @Mock private SportMapper sportMapper;
+  @Mock private SecurityContext securityContext;
+  @Mock private RankService rankService;
+  @InjectMocks private UserServiceImp userServiceImp;
 
   @Test
   void updateUserInfo() {
@@ -95,5 +90,61 @@ class UserServiceImpTest extends BaseTest {
     verify(user, times(1)).getSportUsers();
     assertTrue(sportUsers.contains(sportUser));
     verify(userRepository).save(user);
+  }
+
+  @Test
+  void getUserByName() {
+    String username = "testUser";
+
+    // User
+    User user = new User();
+    user.setId(1L);
+    user.setName(username);
+    user.setRank(1000);
+    when(userRepository.findUserByName(username)).thenReturn(Optional.of(user));
+
+    // Sport
+    Sport sport = new Sport();
+    sport.setId(1L);
+    sport.setName("Tennis");
+    sport.setEmoji("\uD83C\uDFBE");
+    sport.setBackgroundImageURL("./assets/sport-component-tennis.png");
+
+    // SportUser
+    SportUser sportUser = new SportUser(user, sport);
+    user.getSportUsers().add(sportUser);
+
+    // SportDTO
+    SportDTO sportDTO =
+        SportDTO.builder()
+            .name(sport.getName())
+            .emoji(sport.getEmoji())
+            .backgroundUImageURL(sport.getBackgroundImageURL())
+            .build();
+
+    List<SportDTO> sports = new ArrayList<>();
+    sports.add(sportDTO);
+
+    // Event
+    Event event = mock(Event.class);
+    event.setSport(sport);
+
+    EventPlayer eventPlayer = mock(EventPlayer.class);
+
+    when(eventPlayer.getEvent()).thenReturn(event);
+    when(eventPlayer.getEvent().getSport()).thenReturn(sport);
+
+    user.getEventsPlayed().add(eventPlayer);
+
+    doNothing().when(rankService).updatePlayersRanks(event);
+
+    UserDTO expectedUserDTO =
+        UserDTO.builder().name(user.getName()).elo(user.getRank()).sports(sports).build();
+
+    UserDTO actualUserDTO = userServiceImp.getUserByName(username);
+
+    assertEquals(expectedUserDTO.getName(), actualUserDTO.getName());
+    assertEquals(expectedUserDTO.getElo(), actualUserDTO.getElo());
+    assertEquals(expectedUserDTO.getSports().size(), actualUserDTO.getSports().size());
   }
 }

--- a/backend/sportsmatch/src/test/resources/application-test.properties
+++ b/backend/sportsmatch/src/test/resources/application-test.properties
@@ -3,3 +3,7 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+app.sportsmingle.num-game-threshold=5,15,25
+app.sportsmingle.k-factors=25.0,15.0,10.0
+app.sportsmingle.k-factor-default=5.0


### PR DESCRIPTION
Implemented ELO rating system `updatePlayersRanks(Event event)` that calculates players ranks base from the result of the match
- It calculates ranks when the match is valid.
- If players in the match rankings are not updated,
- It will skip events that are invalid and events where players have already updated their ranks.
- It updates ranks of both players in the event.
- The method runs every time a user is fetched (iterates over events that the player has).

 
Created Endpoint : `/api/v1/user/get/{username}`
that returns `UserDTO` of the `User`

`Player who won`
![Screenshot 2024-03-24 101806](https://github.com/MatejFrnka/sportsmatch/assets/134836290/e738fb5d-7894-4087-83e8-27cefc339ac4)

`Player who lost`
![Screenshot 2024-03-24 101824](https://github.com/MatejFrnka/sportsmatch/assets/134836290/175f8ca0-ff0f-4c5e-9cea-e3caa2c14991)

Created Endpoint : `/api/v1/auth/me`
that returns `UserDTO` of the authenticated `User`
![Screenshot 2024-03-24 101838](https://github.com/MatejFrnka/sportsmatch/assets/134836290/94b72012-fa37-4696-99b4-d1c88dee0b51)




