### PR TITLE
SMA-106: handle logged out user in join event popup window

### DIFF
--- a/frontend/sportsmatch-app/src/components/HostEventComponent.tsx
+++ b/frontend/sportsmatch-app/src/components/HostEventComponent.tsx
@@ -128,7 +128,7 @@ function HostEventComponent() {
       }
     }
     fetchData()
-  }, [nearbyEvents])
+  }, [])
 
   // handle join event pop up after cliking on the event
   const handleEventSelection = (e: EventDTO) => {

--- a/frontend/sportsmatch-app/src/components/HostEventComponent.tsx
+++ b/frontend/sportsmatch-app/src/components/HostEventComponent.tsx
@@ -9,8 +9,6 @@ import {
   HostEventDTO,
   EventDTO,
   ApiError,
-  OpenAPI,
-  ExSecuredEndpointService,
 } from '../generated/api'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
@@ -44,8 +42,6 @@ function HostEventComponent() {
   const [nearbyEvents, setNearbyEvents] = useState<EventDTO[]>([])
   const [selectedEvent, setSelectedEvent] = useState<EventDTO>()
   const { isOpen, toggle } = useModal()
-  const [usersRank, setUsersRank] = useState(0)
-  const [userIsInRank, setUserIsInRank] = useState(false)
   const [searchQuery, setSearchQuery] = useState<string>('') // no implementation yet
 
   console.log(searchQuery)
@@ -136,34 +132,12 @@ function HostEventComponent() {
 
   // handle join event pop up after cliking on the event
   const handleEventSelection = (e: EventDTO) => {
-    window.scrollTo(0, 0)
     if (isOpen) {
       toggle()
     }
     setSelectedEvent(e)
-    if (usersRank >= e.minElo && usersRank <= e.maxElo) {
-      setUserIsInRank(true)
-    } else {
-      setUserIsInRank(false)
-    }
     toggle()
   }
-
-  // retrieving users rank
-  useEffect(() => {
-    const fetchUsersRank = async () => {
-      OpenAPI.TOKEN = localStorage.getItem('token')!
-      try {
-        const response = await ExSecuredEndpointService.getUserMainPage()
-        if (response) {
-          setUsersRank(response.elo)
-        }
-      } catch (error) {
-        console.error(error as ApiError)
-      }
-    }
-    fetchUsersRank()
-  })
 
   return (
     <>
@@ -295,11 +269,7 @@ function HostEventComponent() {
             </div>
           </div>
           <Modal isOpen={isOpen} toggle={toggle} preventClosing={true}>
-            <JoinEventComponent
-              toggle={toggle}
-              isInRank={userIsInRank}
-              event={selectedEvent!}
-            />
+            <JoinEventComponent toggle={toggle} event={selectedEvent!} />
           </Modal>
           <div className="row">
             <div className="col">

--- a/frontend/sportsmatch-app/src/pages/Index.tsx
+++ b/frontend/sportsmatch-app/src/pages/Index.tsx
@@ -5,13 +5,7 @@ import { SearchBar } from '../components/SearchBar'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import '../styles/Index.css'
-import {
-  ApiError,
-  EventDTO,
-  EventsControllerService,
-  ExSecuredEndpointService,
-  OpenAPI,
-} from '../generated/api'
+import { ApiError, EventDTO, EventsControllerService } from '../generated/api'
 import useModal from '../hooks/UseModal'
 import Modal from '../components/Modal'
 import JoinEventComponent from '../components/JoinEventComponent'
@@ -22,8 +16,6 @@ export default function MainPage() {
   const [selectedSports, setSelectedSports] = useState<string[]>([])
   const [clearFilters, setClearFilters] = useState<boolean>(false)
   const [selectedEvent, setSelectedEvent] = useState<EventDTO>()
-  const [usersRank, setUsersRank] = useState(0)
-  const [userIsInRank, setUserIsInRank] = useState(false)
   const navigate = useNavigate()
   const { isOpen, toggle } = useModal()
   const [page, setPage] = useState<number>(0)
@@ -86,29 +78,8 @@ export default function MainPage() {
       toggle()
     }
     setSelectedEvent(e)
-    if (usersRank >= e.minElo && usersRank <= e.maxElo) {
-      setUserIsInRank(true)
-    } else {
-      setUserIsInRank(false)
-    }
     toggle()
   }
-
-  // retrieving users rank
-  useEffect(() => {
-    const fetchUsersRank = async () => {
-      OpenAPI.TOKEN = localStorage.getItem('token')!
-      try {
-        const response = await ExSecuredEndpointService.getUserMainPage()
-        if (response) {
-          setUsersRank(response.elo)
-        }
-      } catch (error) {
-        console.error(error as ApiError)
-      }
-    }
-    fetchUsersRank()
-  })
 
   const handleLetsPlay = () => {
     navigate('/app')
@@ -161,11 +132,7 @@ export default function MainPage() {
           </div>
         </div>
         <Modal isOpen={isOpen} toggle={toggle} preventClosing={true}>
-          <JoinEventComponent
-            toggle={toggle}
-            isInRank={userIsInRank}
-            event={selectedEvent!}
-          />
+          <JoinEventComponent toggle={toggle} event={selectedEvent!} />
         </Modal>
         <div className="row">
           <div className="col">


### PR DESCRIPTION
If user is not logged in a link to login page shows on the join event popup window
Changed JoinEventComponent so it now handles fetching user's rank.
Updated Index.tsx and HostEventComponent after changes in JoinEventCmponent
![Snímek obrazovky 2024-04-22 195233](https://github.com/MatejFrnka/sportsmatch/assets/131284389/9f2e2536-0fef-4adc-9ec2-28b73c3c6186)
